### PR TITLE
Il revalidate delle notizie scatena il revalidate delle novità

### DIFF
--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -19,6 +19,13 @@ export async function POST(request: NextRequest) {
     if (slug) {
       revalidatePath(`/${slug}`);
 
+      // Gestione caso speciale. Dal momento che le notizie sono usate come
+      // reference, se queste vengono pubblicate andrà rivalidata anche la
+      // pagina che le referenzia.
+      if (slug.includes("notizie")) {
+        revalidatePath("/novita");
+      }
+
       return NextResponse.json({
         revalidate: true,
         slug: `/${slug}`,


### PR DESCRIPTION
Fix per il problema di non aggiornamento della pagina novità a fronte della pubblicazione di una nuova notizia.