### PR TITLE
fix: input group z-index

### DIFF
--- a/src/app/globals.scss
+++ b/src/app/globals.scss
@@ -233,3 +233,8 @@ $utilities: (
   outline: 3px solid rgba(0, 0, 0, 0) !important;
   outline-offset: 3px !important;
 }
+
+// fix input group z-index issue with label text
+.input-group {
+  z-index: 1;
+}


### PR DESCRIPTION
Corregge bug di sovrapposizione di un elemento `label` incluso in `.input-group`.